### PR TITLE
Added aws_profile_name as arg for template file

### DIFF
--- a/infra.tf
+++ b/infra.tf
@@ -421,9 +421,10 @@ data "template_file" "invoke_lambda_function" {
   template = "${file("lighthouse-parallel.tpl")}"
 
   vars = {
-    lambda_init_arn    = "${aws_lambda_function.init.arn}"
-    lambda_init_region = "${local.aws_region}"
-    jobs_table_name    = "${aws_dynamodb_table.lighthouse_metrics_jobs.id}"
+    lambda_aws_profile_name = "${local.aws_profile_name}"
+    lambda_init_arn         = "${aws_lambda_function.init.arn}"
+    lambda_init_region      = "${local.aws_region}"
+    jobs_table_name         = "${aws_dynamodb_table.lighthouse_metrics_jobs.id}"
   }
 }
 

--- a/lighthouse-parallel.tpl
+++ b/lighthouse-parallel.tpl
@@ -24,8 +24,10 @@ parser.add_argument('urls', type=argparse.FileType('r'),
 
 args = parser.parse_args()
 
-lambda_client = boto3.client('lambda', region_name=args.region)
-ddb_client = boto3.client('dynamodb', region_name=args.region)
+session = boto3.Session(profile_name="${lambda_aws_profile_name}")
+
+lambda_client = session.client('lambda', region_name=args.region)
+ddb_client = session.client('dynamodb', region_name=args.region)
 
 lambda_payload = {
     'urls': json.load(args.urls),


### PR DESCRIPTION
The template file assumes the `default` profile name for AWS credentials, it should probably use the same profile specified in the terraform locals declaration. 